### PR TITLE
Add condition translation for failed HTTP requests

### DIFF
--- a/api/v2/conditions.lisp
+++ b/api/v2/conditions.lisp
@@ -54,8 +54,8 @@
   (:report
    (lambda (con stream)
      (format stream "HTTP request failed.~%Message: ~A~%Original condition: ~A~%"
-             (api-timeout-message con)
-             (api-timeout-condition con)))))
+             (api-request-failed-message con)
+             (api-request-failed-condition con)))))
 
 (define-condition api-no-connection (api-timeout)
   ())

--- a/api/v2/protocol/call-wrapper.lisp
+++ b/api/v2/protocol/call-wrapper.lisp
@@ -62,5 +62,12 @@ has returned an unknown condition."))
          :api-error-description "A request was made with a method that is not allowed."))
 
 (defmethod %handle-dex-condition (condition status)
-  (signal-condition-from-response
-   (jojo:parse (dexador.error:response-body condition) :as :hash-table)))
+  (let ((body (dexador.error:response-body condition)))
+    (if (typep body 'simple-string)
+        (signal-condition-from-response (jojo:parse body :as :hash-table))
+        (let* ((status (dexador.error:response-status condition))
+               (message (format nil "Server replied with HTTP status: ~D"
+                                status)))
+          (error 'api-request-failed
+                 :api-request-failed-condition condition
+                 :api-request-failed-message message)))))


### PR DESCRIPTION
HTTP requests that fail for transport related reasons (as opposed to API related reasons) do not contain a response body suitable for `signal-condition-from-response`. Responses with status 5xx are an example of this case.